### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ Register the bundle by updating `AppKernel.php`:
     <?php
 
 	// in AppKernel::registerBundles()
-	$bundles = array(
-    	// ...
-    	new Creads\Api2SymfonyBundle\Api2SymfonyBundle(),
-    	// ...
-	);
+	if (in_array($this->getEnvironment(), ['dev', 'test'])) {
+    	    // ...
+    	    $bundles[] = new Creads\Api2SymfonyBundle\Api2SymfonyBundle();
+    	    // ...
+	};
 
 ## Use case
 


### PR DESCRIPTION
I would suggest loading the bundle in dev/test environments only, the same way `SensioGeneratorBundle` is usually loaded, as usually no one really generates any code in prod.
